### PR TITLE
Allowing clients to set connection timeouts.

### DIFF
--- a/src/main/java/com/semantics3/api/ConnectionBuilder.java
+++ b/src/main/java/com/semantics3/api/ConnectionBuilder.java
@@ -1,0 +1,25 @@
+package com.semantics3.api;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+public class ConnectionBuilder {
+    private static final String USER_AGENT_KEY = "User-Agent";
+    private static final String USER_AGENT_VALUE = "Semantics3 Java Library";
+
+    public HttpURLConnection buildConnection(String req, ConnectionProperties connectionProperties)
+            throws IOException, URISyntaxException {
+        URL url = new URL(req);
+        url = url.toURI().normalize().toURL();
+
+        HttpURLConnection request = (HttpURLConnection) url.openConnection();
+        request.setRequestProperty(USER_AGENT_KEY, USER_AGENT_VALUE);
+
+        request.setConnectTimeout(connectionProperties.getConnectionTimeout());
+        request.setReadTimeout(connectionProperties.getReadTimeout());
+
+        return request;
+    }
+}

--- a/src/main/java/com/semantics3/api/ConnectionProperties.java
+++ b/src/main/java/com/semantics3/api/ConnectionProperties.java
@@ -1,0 +1,25 @@
+package com.semantics3.api;
+
+public class ConnectionProperties {
+    private static final int DEFAULT_NO_TIMEOUT = 0;
+
+    private int readTimeout = DEFAULT_NO_TIMEOUT;
+    private int connectionTimeout = DEFAULT_NO_TIMEOUT;
+
+
+    public int getReadTimeout() {
+        return readTimeout;
+    }
+
+    public void setReadTimeout(int readTimeout) {
+        this.readTimeout = readTimeout;
+    }
+
+    public int getConnectionTimeout() {
+        return connectionTimeout;
+    }
+
+    public void setConnectionTimeout(int connectionTimeout) {
+        this.connectionTimeout = connectionTimeout;
+    }
+}

--- a/src/main/java/com/semantics3/api/Semantics3Request.java
+++ b/src/main/java/com/semantics3/api/Semantics3Request.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.net.HttpURLConnection;
+import java.net.SocketTimeoutException;
 import java.net.URISyntaxException;
 import java.net.URLEncoder;
 import java.util.HashMap;
@@ -87,6 +88,9 @@ public class Semantics3Request{
             }
             return json;
         }
+        catch (SocketTimeoutException e) {
+        	throw e;
+		}
         catch (IOException e) {
             InputStream error = ((HttpURLConnection) request).getErrorStream();
             JSONObject json = new JSONObject(new JSONTokener(error));
@@ -136,6 +140,9 @@ public class Semantics3Request{
         }
         return json;
         }
+		catch (SocketTimeoutException e) {
+			throw e;
+		}
         catch (IOException e) {
             InputStream error = ((HttpURLConnection) request).getErrorStream();
             JSONObject json = new JSONObject(new JSONTokener(error));

--- a/src/main/java/com/semantics3/api/Semantics3Request.java
+++ b/src/main/java/com/semantics3/api/Semantics3Request.java
@@ -16,6 +16,7 @@ import java.net.HttpURLConnection;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLEncoder;
+import java.sql.Connection;
 import java.util.HashMap;
 
 public class Semantics3Request{
@@ -30,6 +31,19 @@ public class Semantics3Request{
 	private HashMap<String,JSONObject> query = new HashMap<String, JSONObject>();
 	private JSONObject queryResult;
 	private StringBuffer urlBuilder;
+	private ConnectionProperties connectionProperties;
+
+	public Semantics3Request(String apiKey, String apiSecret, String endpoint, ConnectionProperties connectionProperties) {
+		this(apiKey, apiSecret, endpoint);
+
+		this.connectionProperties = connectionProperties;
+	}
+	
+	public Semantics3Request(String apiKey, String apiSecret, ConnectionProperties connectionProperties) {
+		this(apiKey, apiSecret);
+
+		this.connectionProperties = connectionProperties;
+	}
 	
 	public Semantics3Request(String apiKey, String apiSecret, String endpoint) {
 		this(apiKey, apiSecret);

--- a/src/main/java/com/semantics3/api/Semantics3Request.java
+++ b/src/main/java/com/semantics3/api/Semantics3Request.java
@@ -32,41 +32,38 @@ public class Semantics3Request{
 	private ConnectionProperties connectionProperties;
 
 	public Semantics3Request(String apiKey, String apiSecret, String endpoint, ConnectionProperties connectionProperties) {
-		this(apiKey, apiSecret, endpoint);
+		if (apiKey == null) {
+			throw new Semantics3Exception(
+					"API Credentials Missing",
+					"You did not supply an apiKey. Please sign up at https://semantics3.com/ to obtain your api_key."
+			);
+		}
+		if (apiSecret == null) {
+			throw new Semantics3Exception(
+					"API Credentials Missing",
+					"You did not supply an apiSecret. Please sign up at https://semantics3.com/ to obtain your api_key."
+			);
+		}
+		this.apiKey    = apiKey;
+		this.apiSecret = apiSecret;
+		this.consumer = new DefaultOAuthConsumer(apiKey, apiSecret);
+		consumer.setTokenWithSecret("", "");
+
+		this.endpoint = endpoint;
 
 		this.connectionProperties = connectionProperties;
 	}
 
 	public Semantics3Request(String apiKey, String apiSecret, ConnectionProperties connectionProperties) {
-		this(apiKey, apiSecret);
-
-		this.connectionProperties = connectionProperties;
+		this(apiKey, apiSecret, null, connectionProperties);
 	}
 	
 	public Semantics3Request(String apiKey, String apiSecret, String endpoint) {
-		this(apiKey, apiSecret);
-
-		this.endpoint = endpoint;
+		this(apiKey, apiSecret, endpoint, new ConnectionProperties());
 	}
 
     public Semantics3Request(String apiKey, String apiSecret) {
-        if (apiKey == null) {
-            throw new Semantics3Exception(
-                    "API Credentials Missing",
-                    "You did not supply an apiKey. Please sign up at https://semantics3.com/ to obtain your api_key."
-            );
-        }
-        if (apiSecret == null) {
-            throw new Semantics3Exception(
-                    "API Credentials Missing",
-                    "You did not supply an apiSecret. Please sign up at https://semantics3.com/ to obtain your api_key."
-            );
-        }
-
-        this.apiKey    = apiKey;
-        this.apiSecret = apiSecret;
-        this.consumer = new DefaultOAuthConsumer(apiKey, apiSecret);
-        consumer.setTokenWithSecret("", "");
+		this(apiKey, apiSecret, null, new ConnectionProperties());
     }
 
 	protected JSONObject fetch(String endpoint, String params) throws

--- a/src/main/java/com/semantics3/api/Semantics3Request.java
+++ b/src/main/java/com/semantics3/api/Semantics3Request.java
@@ -32,24 +32,9 @@ public class Semantics3Request{
 	private StringBuffer urlBuilder;
 	
 	public Semantics3Request(String apiKey, String apiSecret, String endpoint) {
-		if (apiKey == null) { 
-			throw new Semantics3Exception(
-					"API Credentials Missing",
-					"You did not supply an apiKey. Please sign up at https://semantics3.com/ to obtain your api_key."
-				);
-		}
-		if (apiSecret == null) { 
-			throw new Semantics3Exception(
-					"API Credentials Missing",
-					"You did not supply an apiSecret. Please sign up at https://semantics3.com/ to obtain your api_key."
-				);
-		}
+		this(apiKey, apiSecret);
 
-		this.apiKey    = apiKey;
-		this.apiSecret = apiSecret;
-		this.endpoint  = endpoint;
-		this.consumer = new DefaultOAuthConsumer(apiKey, apiSecret);
-		consumer.setTokenWithSecret("", "");
+		this.endpoint = endpoint;
 	}
 
     public Semantics3Request(String apiKey, String apiSecret) {

--- a/src/main/java/com/semantics3/api/Semantics3Request.java
+++ b/src/main/java/com/semantics3/api/Semantics3Request.java
@@ -14,9 +14,7 @@ import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.net.HttpURLConnection;
 import java.net.URISyntaxException;
-import java.net.URL;
 import java.net.URLEncoder;
-import java.sql.Connection;
 import java.util.HashMap;
 
 public class Semantics3Request{
@@ -38,7 +36,7 @@ public class Semantics3Request{
 
 		this.connectionProperties = connectionProperties;
 	}
-	
+
 	public Semantics3Request(String apiKey, String apiSecret, ConnectionProperties connectionProperties) {
 		this(apiKey, apiSecret);
 
@@ -82,10 +80,7 @@ public class Semantics3Request{
 					.append("?q=")
 					.append(URLEncoder.encode(params, "UTF-8"))
 					.toString();
-		URL url = new URL(req);
-        url = url.toURI().normalize().toURL();
-		HttpURLConnection request = (HttpURLConnection) url.openConnection();
-		request.setRequestProperty("User-Agent", "Semantics3 Java Library");
+		HttpURLConnection request = new ConnectionBuilder().buildConnection(req, this.connectionProperties);
 		consumer.sign(request);
 		request.connect();
         try {
@@ -118,10 +113,7 @@ public class Semantics3Request{
                 .append(API_BASE)
                 .append(endpoint)
                 .toString();
-        URL url = new URL(req);
-        url = url.toURI().normalize().toURL();
-        HttpURLConnection request = (HttpURLConnection) url.openConnection();
-        request.setRequestProperty("User-Agent", "Semantics3 Java Library");
+		HttpURLConnection request = new ConnectionBuilder().buildConnection(req, this.connectionProperties);
         if(method == "POST") {
             request.setDoInput(true);
             request.setDoOutput(true);


### PR DESCRIPTION
This resolves Semantics3/semantics3-java#8

**Backward compatibility:** clients using the existing constructors would see no change; the default timeout is no-timeout, and that is preserved via the default options via `new ConnectionProperties()` in those constructors.

Note: If a client does explicitly set timeouts via the new construtors, a timeout will result in a `java.net.SocketTimeoutException` propagating up to the client code, not the existing `IOException` handler which processes the error stream (there wouldn't be one in the case of a socket timeout, and so this code would result in an NPE)